### PR TITLE
ログイン状態によってページ遷移先を変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [:index, :show]
-
+  before_action :authenticate_user!,except:[:index,:show,:new]
+  before_action :set_prototype,only:[:show,:edit,:update,:destroy]
+  before_action :contributor_confirmation, only: [:edit, :update,:destroy]
 
   def index
     @prototypes=Prototype.includes(:user)
@@ -21,19 +22,16 @@ class PrototypesController < ApplicationController
   end
 
 def show
-   @prototype = Prototype.find(params[:id]) 
    @comment = Comment.new
    @comments = @prototype.comments.includes(:user)
 
 end
 
 def edit
-  @prototype = Prototype.find(params[:id]) 
+
 end
 
 def update
-  @prototype = Prototype.find(params[:id])
-
   if @prototype.update(prototype_params)
     redirect_to root_path
   else
@@ -42,21 +40,26 @@ def update
 end
 
 def destroy
-  @prototype = Prototype.find(params[:id])
   @prototype.destroy
   redirect_to prototypes_path
 end
   
+
   private
+
     def prototype_params
       params.require(:prototype).permit(:title, :catch_copy, :concept, :image,).merge(user_id: current_user.id)
     end
 
-    def move_to_index
-      unless user_signed_in?
-        redirect_to action: :index
-      end
+    def set_prototype
+      @prototype = Prototype.find(params[:id]) 
     end
+
+
+    def contributor_confirmation
+      redirect_to root_path unless @prototype.user == current_user
+    end
+   
   
   end  
 


### PR DESCRIPTION
#.未ログイン閲覧不可
 1.プロトタイプ新規投稿ページ
 1.プロトタイプ編集ページ
 1.プロトタイプ削除機能（ページはありませんが、他と同様の実装方法で制限をかけましょう）
 1.ログインしていない状態でも遷移できるページ

#ログイン閲覧可
 1.トップページ
 1.プロトタイプ詳細ページ
 1.ユーザー詳細ページ
 1.ユーザー新規登録ページ
 1.ログインページ