### PR TITLE
未ログイン状態のページ遷移再設定

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!,except:[:index,:show,:new]
+  before_action :authenticate_user!,except:[:index,:show]
   before_action :set_prototype,only:[:show,:edit,:update,:destroy]
-  before_action :contributor_confirmation, only: [:edit, :update,:destroy]
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy]
 
   def index
     @prototypes=Prototype.includes(:user)
@@ -60,7 +60,7 @@ end
 
 
     def contributor_confirmation
-      redirect_to root_path unless @prototype.user == current_user
+      redirect_to new_user_session_path unless @prototype.user == current_user
     end
    
   

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -11,6 +11,11 @@
           <%= link_to "編集する", edit_prototype_path(@prototype), class: :prototype__btn %>
           <%= link_to "削除する", prototype_path(@prototype),method: :delete, class: :prototype__btn %>
         </div>
+        <% else %>
+          <div class="prototype__manage">
+          <%= link_to "編集する", new_user_session_path, class: :prototype__btn %>
+          <%= link_to "削除する", new_user_session_path, class: :prototype__btn %>
+        </div>
       <% end %>
 
       <div class="prototype__image">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,11 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
+      <% if user_signed_in? %>
         <%= link_to "#{@user_name}さんの情報", user_path(@user.id), class: :greeting__link%>
+        <% else %>
+         <%= link_to "#{@user_name}さんの情報", new_user_session_path, class: :greeting__link%> 
+       <% end %>
       </h2>
       <table class="table">
         <tbody>


### PR DESCRIPTION
#user_signed_in?でボタンごとの直接リダイレクト先を指定
#before_action :authenticate_user!のnewアクションを削除